### PR TITLE
[TAG-1831]: select edge case

### DIFF
--- a/components/angular-tomitribe-select/package.json
+++ b/components/angular-tomitribe-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-tomitribe-select",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Tomitribe select directives",
   "repository": "https://github.com/tomitribe/mykola/tree/master/components/angular-tomitribe-select",
   "license": "MIT",

--- a/components/angular-tomitribe-select/src/tomitribe-select.ts
+++ b/components/angular-tomitribe-select/src/tomitribe-select.ts
@@ -43,6 +43,15 @@ module tomitribe_select {
             angular.element(uiSelect.focusInput).on('focus', function () {
                 uiSelect.activate();
             });
+
+            angular.element(uiSelect.focusInput).on('blur', function() {
+                //On blur when we don't have element, we must force the uiSelect to close
+                if(uiSelect.items && uiSelect.items.length === 0) {
+                    uiSelect.close();
+                }
+            });
+
+
         }
     }
 }


### PR DESCRIPTION
When we don't have elements in the list, and we press TAB, the ui-select dropdown does not lose the .focus css class. 
So we need to force that behaviour, closing the dropdown