### PR TITLE
TAG-3045 - remove bad open on select

### DIFF
--- a/components/angular-tomitribe-select/package.json
+++ b/components/angular-tomitribe-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-tomitribe-select",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Tomitribe select directives",
   "repository": "https://github.com/tomitribe/mykola/tree/master/components/angular-tomitribe-select",
   "license": "MIT",

--- a/components/angular-tomitribe-select/src/tomitribe-select.ts
+++ b/components/angular-tomitribe-select/src/tomitribe-select.ts
@@ -124,8 +124,6 @@ module tomitribe_select {
             // multiple selects have no focusser
             if (uiSelect.multiple) {
                 angular.element(uiSelect.focusInput).on('focus', focusHandler);
-                // patch closing multiple on select, it should not close
-                scope.$on('uis:select', focusHandler);
             } else {
                 angular.element(uiSelect.focusser).on('focus', focusHandler);
             }


### PR DESCRIPTION
This functionality might be achieved by using ```close-on-select="false"``` attribute on ui-select. 
This implementation cause some problems. 