### PR TITLE
TAG-3979 - new directive close esc

### DIFF
--- a/components/angular-tomitribe-select/package.json
+++ b/components/angular-tomitribe-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-tomitribe-select",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Tomitribe select directives",
   "repository": "https://github.com/tomitribe/mykola/tree/master/components/angular-tomitribe-select",
   "license": "MIT",

--- a/components/angular-tomitribe-select/src/tomitribe-select.ts
+++ b/components/angular-tomitribe-select/src/tomitribe-select.ts
@@ -328,7 +328,7 @@ module tomitribe_select {
         function link(scope, element, attrs, uiSelectCtrl) {
             if (attrs.tribeSelectOnEsc && document.querySelectorAll(attrs.tribeSelectOnEsc).length && uiSelectCtrl.searchInput && uiSelectCtrl.multiple) {
                 uiSelectCtrl.searchInput.bindFirst('keydown', function (event) {
-                    //we cannot trust in uiSelectCtrl.open
+                    //we cannot trust in uiSelectCtrl.open: its only updated after this event
                     if (event.keyCode === 27 && element.find('.ui-select-choices').hasClass('ng-hide')) {
                         event.stopImmediatePropagation();
                         //Create new event and fire in $document

--- a/components/angular-tomitribe-select/src/tomitribe-select.ts
+++ b/components/angular-tomitribe-select/src/tomitribe-select.ts
@@ -28,7 +28,8 @@ module tomitribe_select {
         .directive('tribeSelectRedrawOnTagging', tribeSelectRedrawOnTagging)
         .directive('tribeSelectDontCloseOnClick', tribeSelectDontCloseOnClick)
         .directive('tribeSelectFetchOnSelect', tribeSelectFetchOnSelect)
-        .directive('tribeSelectOnTab', ['$timeout', tribeSelectOnTab]);
+        .directive('tribeSelectOnTab', ['$timeout', tribeSelectOnTab])
+        .directive('tribeSelectOnEsc', ['$document', tribeSelectOnEsc]);
 
     function tribeSelectPreventTab($timeout) {
         return {
@@ -314,6 +315,28 @@ module tomitribe_select {
           if (uiSelect.items.length < fetchItemsCount) uiSelect.refresh(attrs.refresh);
         });
       }
+    }
+
+    function tribeSelectOnEsc($document) {
+        return {
+            restrict: 'A',
+            require: 'uiSelect',
+            replace: false,
+            link: link
+        };
+
+        function link(scope, element, attrs, uiSelectCtrl) {
+            if (attrs.tribeSelectOnEsc && document.querySelectorAll(attrs.tribeSelectOnEsc).length && uiSelectCtrl.searchInput && uiSelectCtrl.multiple) {
+                uiSelectCtrl.searchInput.bindFirst('keydown', function (event) {
+                    //we cannot trust in uiSelectCtrl.open
+                    if (event.keyCode === 27 && element.find('.ui-select-choices').hasClass('ng-hide')) {
+                        event.stopImmediatePropagation();
+                        //Create new event and fire in $document
+                        $document.trigger($.Event('keydown', {keyCode: 27, which: 27}));
+                    }
+                });
+            }
+        }
     }
 
     // todo: fix proper interfacing

--- a/components/angular-tomitribe-tags/package.json
+++ b/components/angular-tomitribe-tags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-tomitribe-tags",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "Tomitribe tags input",
   "repository": "https://github.com/tomitribe/mykola/tree/master/components/angular-tomitribe-tags",
   "license": "MIT",

--- a/components/angular-tomitribe-tags/package.json
+++ b/components/angular-tomitribe-tags/package.json
@@ -1,13 +1,13 @@
 {
   "name": "angular-tomitribe-tags",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "Tomitribe tags input",
   "repository": "https://github.com/tomitribe/mykola/tree/master/components/angular-tomitribe-tags",
   "license": "MIT",
   "main": "index.ts",
   "dependencies": {
     "angular-tomitribe-common": "^0.0.1",
-    "angular-tomitribe-select": "^0.0.25",
+    "angular-tomitribe-select": "^0.0.26",
     "angular": "^1.5.8",
     "angular-sanitize": "^1.5.8",
     "ui-select": "^0.19.6",

--- a/components/angular-tomitribe-tags/src/tags.view.pug
+++ b/components/angular-tomitribe-tags/src/tags.view.pug
@@ -17,7 +17,8 @@ on-remove="refreshDuplicateValidation($select.selected)",
 close-on-select="false",
 tribe-tags-on-blur,
 tribe-select-open-on-focus,
-tribe-select-prevent-tab
+tribe-select-prevent-tab,
+tribe-select-on-esc=".modal",
 )
   ui-select-match(
   class="{{$item.$$invalid ? 'invalid' : ''}}",


### PR DESCRIPTION
Created a new directive for ui-select, that when we press ESC and the suggestions window is close , triggers a new keydown event to $document. This will make the modal window to close, like any other input. 