### PR TITLE
TAG-4085 - tribe tooltip add position

### DIFF
--- a/components/angular-tomitribe-tooltip/package.json
+++ b/components/angular-tomitribe-tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-tomitribe-tooltip",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Tomitribe component floating tooltip",
   "repository": "https://github.com/tomitribe/mykola/tree/master/components/angular-tomitribe-tooltip",
   "license": "MIT",

--- a/components/angular-tomitribe-tooltip/src/tomitribe-tooltip.scss
+++ b/components/angular-tomitribe-tooltip/src/tomitribe-tooltip.scss
@@ -15,11 +15,17 @@
 .tooltip-is-active {
   opacity: 1;
 
-  &.tooltip-top {
+  &.tooltip-top,
+  &.tooltip-top-left,
+  &.tooltip-top-middle,
+  &.tooltip-top-right {
      transform: translateY(-14px);
   }
 
-  &.tooltip-bottom {
+  &.tooltip-bottom,
+  &.tooltip-bottom-left,
+  &.tooltip-bottom-middle,
+  &.tooltip-bottom-right {
     transform: translateY(14px);
   }
 
@@ -51,7 +57,10 @@
 }
 
 // Tooltip direction modifiers
-.tooltip-top {
+.tooltip-top,
+.tooltip-top-left,
+.tooltip-top-middle,
+.tooltip-top-right {
   .tooltip__label::after{
     top: 100%;
     left: 50%;
@@ -65,7 +74,10 @@
 
 }
 
-.tooltip-bottom {
+.tooltip-bottom,
+.tooltip-bottom-left,
+.tooltip-bottom-middle,
+.tooltip-bottom-right {
   .tooltip__label::after{
     bottom: 100%;
     left: 50%;

--- a/components/angular-tomitribe-tooltip/src/tomitribe-tooltip.ts
+++ b/components/angular-tomitribe-tooltip/src/tomitribe-tooltip.ts
@@ -137,12 +137,12 @@ module tomitribe_fab {
                 top = $element.offset().top,
                 left = $element.offset().left;
 
-            if (positions[0] === 'top' || positions[0] === 'bottom')
+            if (positions.indexOf('top') > -1 || positions.indexOf('bottom') > -1)
             {
                 let leftPosition;
-                if(positions[1] === 'left') {
+                if(positions.indexOf('left') > -1) {
                     leftPosition = left - width;
-                } else if(positions[1] === 'right') {
+                } else if(positions.indexOf('right') > -1) {
                     leftPosition = left;
                 } else {
                     leftPosition = left - (tooltip.outerWidth() / 2) + (width / 2);
@@ -151,10 +151,10 @@ module tomitribe_fab {
                 tooltip.css(
                     {
                         left: leftPosition,
-                        top: positions[0] === 'top' ? top - tooltip.outerHeight() : top + height
+                        top: positions.indexOf('top') > -1 ? top - tooltip.outerHeight() : top + height
                     });
             }
-            else if (positions[0] === 'left')
+            else if (positions.indexOf('left') > -1)
             {
                 tooltip.css(
                     {
@@ -162,7 +162,7 @@ module tomitribe_fab {
                         top: top + (height / 2) - (tooltip.outerHeight() / 2)
                     });
             }
-            else if (positions[0] === 'right')
+            else if (positions.indexOf('right') > -1)
             {
                 tooltip.css(
                     {

--- a/components/angular-tomitribe-tooltip/src/tomitribe-tooltip.ts
+++ b/components/angular-tomitribe-tooltip/src/tomitribe-tooltip.ts
@@ -137,31 +137,23 @@ module tomitribe_fab {
                 top = $element.offset().top,
                 left = $element.offset().left;
 
-            if (positions.indexOf('top') > -1 || positions.indexOf('bottom') > -1)
-            {
-                let leftPosition;
-                if(positions.indexOf('left') > -1) {
-                    leftPosition = left - width;
-                } else if(positions.indexOf('right') > -1) {
-                    leftPosition = left;
-                } else {
-                    leftPosition = left - (tooltip.outerWidth() / 2) + (width / 2);
-                }
+            let options = {
+                left: left - (tooltip.outerWidth() / 2) + (width / 2),
+                top: top + (height / 2) - (tooltip.outerHeight() / 2)
+            };
 
-                tooltip.css(
-                    {
-                        left: leftPosition,
-                        top: positions.indexOf('top') > -1 ? top - tooltip.outerHeight() : top + height
-                    });
+            if (positions.indexOf('top') > -1 || positions.indexOf('bottom') > -1) {
+                options.top = positions.indexOf('top') > -1 ? top - tooltip.outerHeight() : top + height
             }
-            else if (positions.indexOf('left') > -1 || positions.indexOf('right') > -1)
-            {
-                tooltip.css(
-                    {
-                        left: positions.indexOf('left') > -1 ? left - tooltip.outerWidth() : left + width,
-                        top: top + (height / 2) - (tooltip.outerHeight() / 2)
-                    });
+            if (positions.indexOf('left') > -1 || positions.indexOf('right') > -1) {
+                if (positions.indexOf('top') > -1 || positions.indexOf('bottom') > -1) {
+                    options.left = positions.indexOf('left') > -1 ? left - width : left;
+                } else {
+                    options.left = positions.indexOf('left') > -1 ? left - tooltip.outerWidth() : left + width
+                }
             }
+
+            tooltip.css(options);
         }
 
         function setTooltipPosition()

--- a/components/angular-tomitribe-tooltip/src/tomitribe-tooltip.ts
+++ b/components/angular-tomitribe-tooltip/src/tomitribe-tooltip.ts
@@ -154,19 +154,11 @@ module tomitribe_fab {
                         top: positions.indexOf('top') > -1 ? top - tooltip.outerHeight() : top + height
                     });
             }
-            else if (positions.indexOf('left') > -1)
+            else if (positions.indexOf('left') > -1 || positions.indexOf('right') > -1)
             {
                 tooltip.css(
                     {
-                        left: left - tooltip.outerWidth(),
-                        top: top + (height / 2) - (tooltip.outerHeight() / 2)
-                    });
-            }
-            else if (positions.indexOf('right') > -1)
-            {
-                tooltip.css(
-                    {
-                        left: left + width,
+                        left: positions.indexOf('left') > -1 ? left - tooltip.outerWidth() : left + width,
                         top: top + (height / 2) - (tooltip.outerHeight() / 2)
                     });
             }

--- a/components/angular-tomitribe-tooltip/src/tomitribe-tooltip.ts
+++ b/components/angular-tomitribe-tooltip/src/tomitribe-tooltip.ts
@@ -175,7 +175,7 @@ module tomitribe_fab {
 
                     tooltip = angular.element('<div/>',
                         {
-                            class: 'tooltip tooltip-' + tribeTooltip.position.split(' ')[0]
+                            class: 'tooltip tooltip'+tribeTooltip.position.split(' ').map(i => '-'+i).join('')
                         });
 
                     tooltipLabel = angular.element('<span/>',

--- a/components/angular-tomitribe-tooltip/src/tomitribe-tooltip.ts
+++ b/components/angular-tomitribe-tooltip/src/tomitribe-tooltip.ts
@@ -85,7 +85,7 @@ module tomitribe_fab {
         tribeTooltip.calcTooltipPosition = calcTooltipPosition;
 
 
-        tribeTooltip.position = angular.isDefined(tribeTooltip.position) ? tribeTooltip.position : 'top';
+        tribeTooltip.position = angular.isDefined(tribeTooltip.position) ? tribeTooltip.position : 'top middle';
 
         $scope.$on('$destroy', function()
         {
@@ -126,28 +126,35 @@ module tomitribe_fab {
         function calcTooltipPosition() {
             if (!angular.isDefined(tribeTooltip) || !angular.isDefined(tooltip)) return;
 
+            let positions = tribeTooltip.position.split(' ');
+
+            if(positions.length === 1) {
+                positions.push("middle");
+            }
+
             var width = $element.outerWidth(),
                 height = $element.outerHeight(),
                 top = $element.offset().top,
                 left = $element.offset().left;
 
-            if (tribeTooltip.position === 'top')
+            if (positions[0] === 'top' || positions[0] === 'bottom')
             {
+                let leftPosition;
+                if(positions[1] === 'left') {
+                    leftPosition = left - width;
+                } else if(positions[1] === 'right') {
+                    leftPosition = left;
+                } else {
+                    leftPosition = left - (tooltip.outerWidth() / 2) + (width / 2);
+                }
+
                 tooltip.css(
                     {
-                        left: left - (tooltip.outerWidth() / 2) + (width / 2),
-                        top: top - tooltip.outerHeight()
+                        left: leftPosition,
+                        top: positions[0] === 'top' ? top - tooltip.outerHeight() : top + height
                     });
             }
-            else if (tribeTooltip.position === 'bottom')
-            {
-                tooltip.css(
-                    {
-                        left: left - (tooltip.outerWidth() / 2) + (width / 2),
-                        top: top + height
-                    });
-            }
-            else if (tribeTooltip.position === 'left')
+            else if (positions[0] === 'left')
             {
                 tooltip.css(
                     {
@@ -155,7 +162,7 @@ module tomitribe_fab {
                         top: top + (height / 2) - (tooltip.outerHeight() / 2)
                     });
             }
-            else if (tribeTooltip.position === 'right')
+            else if (positions[0] === 'right')
             {
                 tooltip.css(
                     {
@@ -184,7 +191,7 @@ module tomitribe_fab {
 
                     tooltip = angular.element('<div/>',
                         {
-                            class: 'tooltip tooltip-' + tribeTooltip.position
+                            class: 'tooltip tooltip-' + tribeTooltip.position.split(' ')[0]
                         });
 
                     tooltipLabel = angular.element('<span/>',

--- a/src/templates/tooltip.jade
+++ b/src/templates/tooltip.jade
@@ -7,10 +7,46 @@ div
         div.panel
             div.row
                 div.col-sm-12
-                    h4 Simple Tooltip Example
+                    h4 Simple Tooltip Example (top middle without position declared)
                     p
                         span Move the mouse over the following text:
                         span(tribe-tooltip='This is a simple tooltip' style="margin-left: 30px") Hover me
+
+                    h4 Simple Tooltip Example (top middle using tribe-tooltip-position="top")
+                    p
+                        span Move the mouse over the following text:
+                        span(tribe-tooltip='This is a simple tooltip' tribe-tooltip-position="top", style="margin-left: 30px") Hover me
+
+                    h4 Simple Tooltip Example (top middle using tribe-tooltip-position="top middle")
+                    p
+                        span Move the mouse over the following text:
+                        span(tribe-tooltip='This is a simple tooltip' tribe-tooltip-position="top middle", style="margin-left: 30px") Hover me
+
+                    h4 Simple Tooltip Example (top left using tribe-tooltip-position="top left")
+                    p
+                        span Move the mouse over the following text:
+                        span(tribe-tooltip='This is a simple tooltip' tribe-tooltip-position="top left" style="margin-left: 30px") Hover me
+
+                    h4 Simple Tooltip Example (top right using tribe-tooltip-position="top right")
+                    p
+                        span Move the mouse over the following text:
+                        span(tribe-tooltip='This is a simple tooltip' tribe-tooltip-position="top right" style="margin-left: 30px") Hover me
+
+                    h4 Simple Tooltip Example (bottom left using tribe-tooltip-position="bottom left")
+                    p
+                        span Move the mouse over the following text:
+                        span(tribe-tooltip='This is a simple tooltip' tribe-tooltip-position="bottom left" style="margin-left: 30px") Hover me
+
+                    h4 Simple Tooltip Example (bottom middle using tribe-tooltip-position="bottom middle")
+                    p
+                        span Move the mouse over the following text:
+                        span(tribe-tooltip='This is a simple tooltip' tribe-tooltip-position="bottom middle" style="margin-left: 30px") Hover me
+
+                    h4 Simple Tooltip Example (bottom right using tribe-tooltip-position="bottom right")
+                    p
+                        span Move the mouse over the following text:
+                        span(tribe-tooltip='This is a simple tooltip' tribe-tooltip-position="bottom right" style="margin-left: 30px") Hover me
+
 
                     h4 Tooltip with Updatable Text
                     p

--- a/src/templates/tooltip.jade
+++ b/src/templates/tooltip.jade
@@ -47,6 +47,16 @@ div
                         span Move the mouse over the following text:
                         span(tribe-tooltip='This is a simple tooltip' tribe-tooltip-position="bottom right" style="margin-left: 30px") Hover me
 
+                    h4 Simple Tooltip Example (left tribe-tooltip-position="left")
+                    p
+                        span Move the mouse over the following text:
+                        span(tribe-tooltip='This is a simple tooltip' tribe-tooltip-position="left" style="margin-left: 30px") Hover me
+
+                    h4 Simple Tooltip Example (right tribe-tooltip-position="right")
+                    p
+                        span Move the mouse over the following text:
+                        span(tribe-tooltip='This is a simple tooltip' tribe-tooltip-position="right" style="margin-left: 30px") Hover me
+
 
                     h4 Tooltip with Updatable Text
                     p


### PR DESCRIPTION
Added to the tribe-tooltip, new type of positioning, passed by the position attribute
Now we allow, for top and bottom: left, right and middle
examples:
top left, top middle, top right

Note: it was only implemented for top and bottom