### PR TITLE
TAG-4122 single select open fix

### DIFF
--- a/components/angular-tomitribe-select/package.json
+++ b/components/angular-tomitribe-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-tomitribe-select",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Tomitribe select directives",
   "repository": "https://github.com/tomitribe/mykola/tree/master/components/angular-tomitribe-select",
   "license": "MIT",

--- a/components/angular-tomitribe-select/src/tomitribe-select.ts
+++ b/components/angular-tomitribe-select/src/tomitribe-select.ts
@@ -198,10 +198,13 @@ module tomitribe_select {
             const key = attrs.tribeSelectSaveSearch || 'id';
             // prevent input clear on select
             uiSelect.resetSearchInput = false;
-            // copy seleted attr to search field
+            // copy selected attr to search field
             const choiceToSearch = () => {
-                uiSelect.search = angular.isObject(uiSelect.selected) ? uiSelect.selected[key] : uiSelect.selected;
-            }
+                let search = angular.isObject(uiSelect.selected) ? uiSelect.selected[key] : uiSelect.selected;
+                if(search) {
+                    uiSelect.search = search
+                }
+            };
             scope.$on('uis:select', choiceToSearch);
             scope.$on('uis:close', choiceToSearch);
         }

--- a/components/angular-tomitribe-tags/package.json
+++ b/components/angular-tomitribe-tags/package.json
@@ -7,7 +7,7 @@
   "main": "index.ts",
   "dependencies": {
     "angular-tomitribe-common": "^0.0.1",
-    "angular-tomitribe-select": "^0.0.27",
+    "angular-tomitribe-select": "^0.0.28",
     "angular": "^1.5.8",
     "angular-sanitize": "^1.5.8",
     "ui-select": "^0.19.6",

--- a/components/angular-tomitribe-tags/package.json
+++ b/components/angular-tomitribe-tags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-tomitribe-tags",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "Tomitribe tags input",
   "repository": "https://github.com/tomitribe/mykola/tree/master/components/angular-tomitribe-tags",
   "license": "MIT",


### PR DESCRIPTION
changes in directive tribe-Select-save-search
When the select the dropdown and you don't select any value, if you click again in the dropdown, it wouldn't open

In this case, angular.isObject(uiSelect.selected) ? uiSelect.selected[key] : uiSelect.selected; is null, that was preventing the dropdown to open
 