### PR TITLE
TAG-4499

### DIFF
--- a/components/angular-tomitribe-select/package.json
+++ b/components/angular-tomitribe-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-tomitribe-select",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "Tomitribe select directives",
   "repository": "https://github.com/tomitribe/mykola/tree/master/components/angular-tomitribe-select",
   "license": "MIT",

--- a/components/angular-tomitribe-select/src/tomitribe-select.ts
+++ b/components/angular-tomitribe-select/src/tomitribe-select.ts
@@ -35,25 +35,23 @@ module tomitribe_select {
     function tribeSelectPreventTab($timeout) {
         return {
             restrict: 'A',
-            require: ['uiSelect', 'ngModel'],
+            require: 'uiSelect',
             replace: false,
             link: link
         };
 
-        function link(scope, element, attrs, crtl) {
+        function link(scope, element, attrs, uiSelectCtrl) {
             if(attrs.tribeSelectPreventTab !== '' && !(attrs.tribeSelectPreventTab === "true")) {
                 return;
             }
 
-            let uiSelectCtrl = crtl[0];
-
             if (uiSelectCtrl.searchInput) {
-                let ngModelCtrl = crtl[1], singleSelectInitialIndex;
-
                 uiSelectCtrl.searchInput.bindFirst('keydown', function (e) {
+                    //TAB
                     if (e.keyCode === 9) {
                         if (!uiSelectCtrl.multiple) {
-                            uiSelectCtrl.activeIndex = singleSelectInitialIndex;
+                            //prevent ui-select event to fire. This event will select the current selected item in the list
+                            e.stopImmediatePropagation();
 
                             if(uiSelectCtrl.tagging) {
                                 uiSelectCtrl.close(true);
@@ -63,28 +61,6 @@ module tomitribe_select {
                         }
                     }
                 });
-
-                scope.$on('uis:activate', ()=> {
-                    $timeout(()=> {
-                        if (!uiSelectCtrl.multiple) {
-                            $timeout(()=> {
-                                singleSelectInitialIndex = findIndex(ngModelCtrl.$viewValue, ngModelCtrl, uiSelectCtrl);
-                            });
-                        }
-                    });
-                });
-            }
-        }
-
-        function findIndex (initial, ngModelCtrl, uiSelectCtrl) {
-            if(!ngModelCtrl.$viewValue) {
-                return -1;
-            }
-
-            if(initial.hasOwnProperty("id")) {
-                return _.findIndex(uiSelectCtrl.items, {id: initial.id})
-            } else {
-                return _.indexOf(uiSelectCtrl.items, initial)
             }
         }
     }

--- a/components/angular-tomitribe-tags/package.json
+++ b/components/angular-tomitribe-tags/package.json
@@ -1,13 +1,13 @@
 {
   "name": "angular-tomitribe-tags",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "description": "Tomitribe tags input",
   "repository": "https://github.com/tomitribe/mykola/tree/master/components/angular-tomitribe-tags",
   "license": "MIT",
   "main": "index.ts",
   "dependencies": {
     "angular-tomitribe-common": "^0.0.1",
-    "angular-tomitribe-select": "^0.0.32",
+    "angular-tomitribe-select": "^0.0.33",
     "angular": "^1.5.8",
     "angular-sanitize": "^1.5.8",
     "ui-select": "^0.19.6",


### PR DESCRIPTION
tribeSelectPreventTab had a problem

When we press TAB and the item is not on the items lists (pagination), the field becomes empty
So instead of finding the index in the items list, on activate, now we prevent propagation.
This way we prevent select.js code
`if (!ctrl.multiple || ctrl.open) ctrl.select(ctrl.items[ctrl.activeIndex], true);
        break;`

to be executed, in this specific case
 
